### PR TITLE
Add support for user-supplied configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,33 @@
 
 mpv_bookmark is a Lua script for the MPV media player that allows you to easily add, remove, and navigate between bookmarks during video playback.
 
+## Configuration
+
+You can configure the variables mentioned in this document by adding overrides  to the following file in your MPV scripts directory:
+  - On Linux, `~/.config/mpv/script-opts/mpv_bookmark.conf`
+  - On Windows, `%APPDATA%\mpv\script-opts\mpv_bookmark.conf`
+
+Create the file if it doesn't exist. You can also create it at `{path-to-mpv}/script-opts/mpv_bookmark.conf` if you want it to affect only a specific instance of MPV.
+
+Supply an override for any of the variables with the desired values. For example, the following configuration is equivalent to the defaults supplied with the script:
+```
+leadin_threshold=7 # how far back to create the bookmark at in seconds
+cleanup_threshold=20 # how far to search when deleting a bookmark in seconds
+pause_after_jump=no #  whether or not to pause the video after jumping to a bookmark
+```
+
 ## Features
 
-- Add a bookmark 7 seconds before the current playback position
+- Add a bookmark `leadin_threshold` seconds before the current playback position
 - Navigate between bookmarks using keyboard shortcuts
-- Remove a bookmark within 20 seconds of the current playback position
+- Remove a bookmark within `cleanup_threshold` seconds of the current playback position
+- Optionally pause the video after jumping to a bookmark
 
 ## Installation
 
-1. Download `mpv_bookmark.zip` from the Releases tab on the right.
-2. Extract the file containing the .lua script to a folder. 
-3. Place the `mpv_bookmark.lua` file in your MPV scripts directory.
+1. Download `mpv_bookmark.zip` from the Releases tab on the right
+2. Extract the file containing the .lua script to a folder
+3. Place the `mpv_bookmark.lua` file in your MPV scripts directory
    - For Linux: `~/.config/mpv/scripts/`
    - For Windows: `%APPDATA%\mpv\scripts\`
 
@@ -20,10 +36,11 @@ mpv_bookmark is a Lua script for the MPV media player that allows you to easily 
 
 The script provides the following keyboard shortcuts:
 
-- **b**: Add a bookmark 7 seconds before the current playback position. If the resulting time is negative, the bookmark will be set to the beginning of the video (0 seconds).
+- **b**: Add a bookmark `leadin_threshold` seconds before the current playback position. If the resulting time is negative, the bookmark will be set to the beginning of the video (0 seconds).
 - **Shift+Left**: Navigate to the previous bookmark.
 - **Shift+Right**: Navigate to the next bookmark.
-- **Shift+B**: Remove the closest bookmark within 20 seconds of the current playback position. If there's no bookmark within that range, an OSD message will be displayed stating that no bookmarks were found within 20 seconds.
+- **Shift+B**: Remove the closest bookmark within `cleanup_threshold` seconds of the current playback position. If there's no bookmark within that range, an OSD message will be displayed stating that no bookmarks were found within the threshold.
+
 ## License
 
 This project is released under the [MIT License](LICENSE.md)

--- a/mpv_bookmark.lua
+++ b/mpv_bookmark.lua
@@ -1,12 +1,20 @@
 local mp = require 'mp'
+local mpopt = require('mp.options')
 local utils = require 'mp.utils'
 
 local bookmarks = {}
 local bookmark_id = 1
 
--- Add a bookmark at the current playback position minus 7 seconds
+-- Override values here at path-to-mpv/script-opts/mpv_bookmark.conf or ~/.config/mpv/script-opts/mpv_bookmark.conf
+local config = {
+    leadin_threshold = 7, -- how far back to create the bookmark at in seconds
+    cleanup_threshold = 20, -- how far to search when deleting a bookmark in seconds
+    pause_after_jump = false -- whether or not to pause the video after jumping to the bookmark
+}
+
+-- Add a bookmark at the current playback position minus config.leadin_threshold seconds
 local function add_bookmark()
-    local current_time = mp.get_property_number("time-pos") - 7
+    local current_time = mp.get_property_number("time-pos") - config.leadin_threshold
     if current_time < 0 then
         current_time = 0
     end
@@ -15,17 +23,17 @@ local function add_bookmark()
     mp.osd_message("Bookmark added at: " .. current_time .. "s")
 end
 
--- Remove a bookmark if within 20 seconds
+-- Remove a bookmark if within config.cleanup_threshold seconds of the current playback position
 local function remove_bookmark()
     local current_time = mp.get_property_number("time-pos")
     for index, bookmark in ipairs(bookmarks) do
-        if math.abs(bookmark.time - current_time) <= 20 then
+        if math.abs(bookmark.time - current_time) <= config.cleanup_threshold then
             table.remove(bookmarks, index)
             mp.osd_message("Bookmark " .. bookmark.id .. " removed")
             return
         end
     end
-    mp.osd_message("No bookmarks found within 20 seconds")
+    mp.osd_message("No bookmarks found within " .. config.cleanup_threshold .. " seconds")
 end
 
 -- Navigate between bookmarks
@@ -42,7 +50,7 @@ local function navigate_bookmarks(direction)
 
     for _, bookmark in ipairs(bookmarks) do
         local time_difference = bookmark.time - current_time
-        if direction == "forward" and time_difference > 0 and time_difference < min_difference then
+        if direction == "forward" and time_difference > time_threshold and time_difference < min_difference then
             nearest_bookmark = bookmark
             min_difference = time_difference
         elseif direction == "backward" and time_difference < -time_threshold and math.abs(time_difference) < min_difference then
@@ -54,13 +62,16 @@ local function navigate_bookmarks(direction)
     if nearest_bookmark then
         mp.set_property_number("time-pos", nearest_bookmark.time)
         mp.osd_message("Jumped to bookmark: " .. nearest_bookmark.id)
+        if config.pause_after_jump then
+            mp.set_property("pause", "yes")
+        end
     else
         mp.osd_message("No bookmarks found in the desired direction")
     end
 end
 
 
-
+mpopt.read_options(config, 'mpv_bookmark')
 mp.add_key_binding("b", "add_bookmark", add_bookmark)
 mp.add_key_binding("Shift+b", "remove_bookmark", remove_bookmark)
 mp.add_key_binding("Shift+LEFT", "navigate_backward", function() navigate_bookmarks("backward") end)


### PR DESCRIPTION
This change adds three configurable options to the script that can be customized by the user to control the search thresholds for creating, removing bookmarks, and optionally pausing after jumping to a bookmark.

Also fixes a latent bug with the time threshold for seeking bookmarks. Seeking forward wasn't using the threshold so it could find the current bookmark and be stuck. This surfaces prominently when pausing on jump.